### PR TITLE
add flag to manually control installation of kernel-devel kernel-headers

### DIFF
--- a/roles/client/defaults/main.yml
+++ b/roles/client/defaults/main.yml
@@ -8,6 +8,7 @@ client_ofed_libs_path:
 client_nvfs_libs_path:
 client_nvidia_libs_path:
 client_build_kernel_modules: true
+client_install_kernel_dev: true
 
 # /etc/beegfs/beegfs-helperd.conf /etc/beegfs/beegfs-client.conf
 client_sys_mgmtd_host: localhost

--- a/roles/client/meta/argument_specs.yml
+++ b/roles/client/meta/argument_specs.yml
@@ -26,7 +26,14 @@ argument_specs:
       client_build_kernel_modules:
         type: bool
         description: Build the client kernel modules
-        default: false
+        default: true
+      client_install_kernel_dev:
+        type: bool
+        description:
+          - Install the kernel development packages
+          - Needed to build the client kernel modules
+          - If the kernel* is filtered out from package manager, it breaks the Ansible module
+        default: true
       client_clusters:
         type: list
         elements: dict

--- a/roles/client/tasks/install.yml
+++ b/roles/client/tasks/install.yml
@@ -18,6 +18,8 @@
     - client_build_kernel_modules
     - (ansible_distribution == 'RedHat') or (ansible_distribution == 'Rocky')
       or (ansible_distribution == 'AlmaLinux')
+    - client_install_kernel_dev is defined
+    - client_install_kernel_dev
   tags:
     - install
 
@@ -29,5 +31,7 @@
     - client_build_kernel_modules is defined
     - client_build_kernel_modules
     - ansible_distribution == 'Ubuntu'
+    - client_install_kernel_dev is defined
+    - client_install_kernel_dev
   tags:
     - install


### PR DESCRIPTION
We need to give the possibility to exclude the execution of the tasks that ensure `kernel-devel` and `kernel-headers` packages because if there are package manager exclude filters (eg: kernel*) they break the execution