### PR TITLE
fix: execute mirrormd command when metadata mirroring is enabled

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -11,8 +11,8 @@
 - name: Import mon playbook
   ansible.builtin.import_playbook: mon.yml
 
-- name: Import client playbook
-  ansible.builtin.import_playbook: client.yml
-
 - name: Import cluster playbook
   ansible.builtin.import_playbook: cluster.yml
+
+- name: Import client playbook
+  ansible.builtin.import_playbook: client.yml

--- a/roles/cluster/handlers/main.yml
+++ b/roles/cluster/handlers/main.yml
@@ -1,18 +1,4 @@
 ---
-- name: Execute metadata enable mirror command
-  ansible.builtin.command: |
-    beegfs-ctl --mirrormd
-  changed_when: false
-  when:
-    - not multi_mode
-
-- name: Execute metadata enable mirrormd command for multi cluster deployment
-  ansible.builtin.command: |
-    beegfs-ctl --cfgFile=/etc/beegfs/{{ item.item.value.sys_mgmtd_host }}/beegfs-client.conf --mirrormd
-  changed_when: false
-  when:
-    - multi_mode
-
 - name: Pause for 30 seconds to propagate definitions
   ansible.builtin.pause:
     seconds: 30

--- a/roles/cluster/meta/main.yml
+++ b/roles/cluster/meta/main.yml
@@ -16,3 +16,6 @@ galaxy_info:
 
 dependencies:
   - role: client
+    vars:
+      # Clients must be disconnected to run mirrormd command succesfully
+      client_start_services: false

--- a/roles/cluster/tasks/buddy_mirror.yml
+++ b/roles/cluster/tasks/buddy_mirror.yml
@@ -168,9 +168,9 @@
         --primary={{ item.value.target_ids[0] }} \
         --secondary={{ item.value.target_ids[1] }} \
         --groupid={{ item.key }}
+      register: beegfsctl_addmetamirrorgroup
       changed_when: false
       loop: "{{ buddymirror_data | dict2items }}"
-      register: beegfsctl_addmirrorgroup
       when:
         - not multi_mode
         - not ( item.key in existing_buddy_mirrorgroups.results
@@ -185,7 +185,33 @@
           --primary={{ item.value.target_ids[0] }} \
           --secondary={{ item.value.target_ids[1] }} \
           --groupid={{ item.key }}
-      notify: Execute metadata enable mirror command
+      tags:
+        - buddy_mirror
+        - meta_mirror
+
+    - name: Set changed status based on addmirrorgroup command results
+      ansible.builtin.set_fact:
+        _changed_status: "{{ item.rc == 0 }}"
+      loop: "{{ beegfsctl_addmetamirrorgroup.results }}"
+      when:
+        - item.item.value.mirror_type == 'metadata'
+        - not multi_mode
+        - not item.skipped is defined
+      tags:
+        - buddy_mirror
+        - meta_mirror
+
+    - name: Execute metadata enable mirror command
+      ansible.builtin.command: |
+        beegfs-ctl --mirrormd
+      changed_when: false
+      register: result
+      retries: 3
+      delay: 5
+      until: result.rc == 0
+      when:
+        - not multi_mode
+        - _changed_status is defined
       tags:
         - buddy_mirror
         - meta_mirror
@@ -257,6 +283,7 @@
         --secondary={{ item.value.target_ids[1] }} \
         --groupid={{ item.key }}
       changed_when: false
+      register: beegfsctl_addmetamirrorgroup_multi
       loop: "{{ buddymirror_data | dict2items }}"
       when:
         - multi_mode
@@ -273,7 +300,43 @@
           --primary={{ item.value.target_ids[0] }} \
           --secondary={{ item.value.target_ids[1] }} \
           --groupid={{ item.key }}
-      notify: Execute metadata enable mirrormd command for multi cluster deployment
+      tags:
+        - buddy_mirror
+        - meta_mirror
+
+
+    - name: Set changed status based on addmirrorgroup command results for multi cluster deployment
+      ansible.builtin.set_fact:
+        _changed_status_multi: "{{ item.rc == 0 }}"
+      loop: "{{ beegfsctl_addmetamirrorgroup_multi.results }}"
+      when:
+        - multi_mode
+        - item.item.value.mirror_type == 'metadata'
+        - not item.skipped is defined
+      tags:
+        - buddy_mirror
+        - meta_mirror
+
+    - name: Execute metadata enable mirrormd command for multi cluster deployment
+      ansible.builtin.command: |
+        beegfs-ctl \
+        --cfgFile=/etc/beegfs/{{ item.value.sys_mgmtd_host | replace('-', '') }}.d/beegfs-client.conf \
+        --mirrormd
+      changed_when: false
+      register: result
+      retries: 3
+      delay: 5
+      until: result.rc == 0
+      loop: "{{ buddymirror_data | dict2items }}"
+      loop_control:
+        label: |
+          beegfs-ctl \
+          --cfgFile=/etc/beegfs/{{ item.value.sys_mgmtd_host | replace('-', '') }}.d/beegfs-client.conf \
+          --mirrormd
+      when:
+        - multi_mode
+        - item.value.mirror_type == 'metadata'
+        - _changed_status_multi is defined
       tags:
         - buddy_mirror
         - meta_mirror

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -7,8 +7,13 @@
   ansible.builtin.import_tasks: buddy_mirror.yml
   run_once: true
 
-- name: Refresh all handlers
-  ansible.builtin.meta: flush_handlers
+- name: Execute beegfs client
+  ansible.builtin.import_role:
+    name: client
+    tasks_from: run
+  vars:
+    # We need the client mounting the Beegfs storage to execute setpattern command
+    client_start_service: true
 
 - name: Execute dir layout
   ansible.builtin.import_tasks: dir_layout.yml


### PR DESCRIPTION
Move mirrormd command that enables metadata mirror from handlers to normal task. This is necessary because before, with the notify/handler method and the calling task being `changed_when: false`, it would never get triggered.