### PR TITLE
enhancement: allow to specify a mgmtd string ID

### DIFF
--- a/extensions/molecule/default/molecule.yml
+++ b/extensions/molecule/default/molecule.yml
@@ -64,6 +64,7 @@ provisioner:
   inventory:
     host_vars:
       beealma95-01:
+        mgmtd_string_id: almamaster
         client_clusters:
           - sys_mgmtd_host: localhost
             cluster_storage_nodes: ["beealma95-01"]

--- a/roles/mgmtd/defaults/main.yml
+++ b/roles/mgmtd/defaults/main.yml
@@ -2,6 +2,7 @@
 mgmtd_start_services: true
 
 # /etc/beegfs/beegfs-mgmt.conf
+mgmtd_string_id: "{{ inventory_hostname_short }}"
 mgmtd_store_mgmtd_directory: /data/beegfs/beegfs_mgmtd
 mgmtd_conn_mgmtd_port_tcp: "8008"
 mgmtd_conn_mgmtd_port_udp: "8008"

--- a/roles/mgmtd/meta/argument_specs.yml
+++ b/roles/mgmtd/meta/argument_specs.yml
@@ -9,6 +9,13 @@ argument_specs:
       - Davide Obbi
     version_added: "1.0.0"
     options:
+      mgmtd_string_id:
+        type: str
+        description:
+          - The string ID of the management server
+          - This ID will be used in server-related log messages
+          - To set to a common name in HA configurations where two mgmtd servers work in active/passive
+        default: "{{ inventory_hostname_short }}"
       mgmtd_start_services:
         type: bool
         description: Start the `beegfs-mgmtd.service`

--- a/roles/mgmtd/tasks/main.yml
+++ b/roles/mgmtd/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: Execute management setup command for single cluster deployment
   ansible.builtin.command: |
-    /opt/beegfs/sbin/beegfs-setup-mgmtd -C -p {{ mgmtd_store_mgmtd_directory }}
+    /opt/beegfs/sbin/beegfs-setup-mgmtd -C -p {{ mgmtd_store_mgmtd_directory }} -S {{ mgmtd_string_id }}
   changed_when: false
   when:
     - mgmtd_target_dir_content.matched == 0


### PR DESCRIPTION
Allow to specify the mgmtd string ID in the setup-mgmtd command. This is useful when we want to setup the mgmtd services in HA where two mgmt nodes work in active/passive setup. 